### PR TITLE
opening DT Seminar series planning to community

### DIFF
--- a/Seminars/README.md
+++ b/Seminars/README.md
@@ -15,7 +15,7 @@ We are currently finding dates for first seminars in November & December. If you
 ## Sign-up as a presenter
 For existing topics, sign up as a presenter by **assigning yourself to an issue** with label `seminar series` and then **commenting with a title** and a few sentences describing your presentations. We will assign a date to each session, once we have researchers from at least two different themes signed up.
 
-We will label issues with `0/idea`, `1/assigned`, `2/scheduled` and `3/completed`.
+We will label issues with `0/idea`, `1/in planning`, `2/scheduled` and `3/completed`.
 
 ## Propose a topic
 We’ve opened an issue in this repository for each topic we’re considering. We'd like your input and "votes" on these, and your suggestions for other topics we haven't thought of. We want to invite everyone to collaborate on shaping this seminar series in something that serves the TRIC-DT research community best.

--- a/Seminars/README.md
+++ b/Seminars/README.md
@@ -1,0 +1,27 @@
+Welcome to our TRIC-DT Seminar Series!
+**Take part** in this community by attending the [next event](#next-events), [propose or upvoting a new topic](#propose-a-topic) or [sign up to present](#sign-up-as-a-presenter)!
+
+# 'Crafting Digital Twins' Seminar Series
+
+The “Crafting Digital Twins: Computational Methods Across Environment, Health & Infrastructure” seminar series will be an interdisciplinary platform for TRIC-DT researchers to share and discuss about the computational methods, algorithms, and models that underpin Digital Twin technology in diverse fields. This series will provide a space for exchange of knowledge and methodologies across the themes of environment, health, and infrastructure, with the aim to cultivate a unified vocabulary and uncover synergies in our work across TRIC-DT.
+
+By uniting researchers to discuss the methodological hurdles in their foundational work, this series will offer immediate value to each team member, enabling you to acquire practical insights applicable to projects at any stage, no matter how “DT-ready”. Beyond the technical learnings, presenting to a broader peer group allows us to see common challenges from fresh perspectives, potentially igniting innovative solutions to our problems.
+
+## Take Part!
+
+## Next events
+We are currently finding dates for first seminars in November & December. If you haven't received an email about this, please email sarana@turing.ac.uk for the doodle link
+
+## Sign-up as a presenter
+For existing topics, sign up as a presenter by **assigning yourself to an issue** with label /seminar_series and then **commenting with a title** and a few sentences describing your presentations. We will assign a date to each session, once we have researchers from at least two different themes signed up.
+
+We will label issues with 0/idea, 1/assigned, 2/scheduled and 3/completed.
+
+## Propose a topic
+We’ve opened an issue in this repository for each topic we’re considering. We'd like your input and "votes" on these, and your suggestions for other topics we haven't thought of. We want to invite everyone to collaborate on shaping this seminar series in something that serves the TRIC-DT research community best.
+
+- Show your interest in a topic with a 👍🏼🎉🚀👎🏼😕
+- Suggest a topic by opening a new issue
+- Add to an existing idea: propose speakers, resources, how would this topic fit into your work?
+
+

--- a/Seminars/README.md
+++ b/Seminars/README.md
@@ -30,4 +30,8 @@ We’ve opened an issue in this repository for each topic we’re considering. W
 - Suggest a topic by opening a new issue
 - Add to an existing idea: propose speakers, resources, how would this topic fit into your work?
 
+</br>
+
+> 🚧 **Code of Conduct**  
+> Our code of conduct is currently in progress. Until then, we expect all participants to uphold principles of respect and inclusivity. Inappropriate behavior may result in exclusion from our seminar series or activities.
 

--- a/Seminars/README.md
+++ b/Seminars/README.md
@@ -5,7 +5,7 @@ Welcome to our TRIC-DT Seminar Series!
 
 The “Crafting Digital Twins: Computational Methods Across Environment, Health & Infrastructure” seminar series will be an interdisciplinary platform for TRIC-DT researchers to share and discuss about the computational methods, algorithms, and models that underpin Digital Twin technology in diverse fields. This series will provide a space for exchange of knowledge and methodologies across the themes of environment, health, and infrastructure, with the aim to cultivate a unified vocabulary and uncover synergies in our work across TRIC-DT.
 
-By uniting researchers to discuss the methodological hurdles in their foundational work, this series will offer immediate value to each team member, enabling you to acquire practical insights applicable to projects at any stage, no matter how “DT-ready”. Beyond the technical learnings, presenting to a broader peer group allows us to see common challenges from fresh perspectives, potentially igniting innovative solutions to our problems.
+By focusing on the methodological hurdles of the foundational work, this series will offer immediate value to researchers and developers, enabling everyone to acquire practical insights applicable to their project at any stage, no matter how “DT-ready”. Beyond the technical learnings, presenting to a broader peer group allows us to see common challenges from fresh perspectives, potentially igniting innovative solutions to common problems.
 
 # Take Part!
 

--- a/Seminars/README.md
+++ b/Seminars/README.md
@@ -7,6 +7,12 @@ The “Crafting Digital Twins: Computational Methods Across Environment, Health 
 
 By focusing on the methodological hurdles of the foundational work, this series will offer immediate value to researchers and developers, enabling everyone to acquire practical insights applicable to their project at any stage, no matter how “DT-ready”. Beyond the technical learnings, presenting to a broader peer group allows us to see common challenges from fresh perspectives, potentially igniting innovative solutions to common problems.
 
+Each Seminar will follow roughly this format:
+- Total of 1,5 hour duration
+- 10 minutes of welcome & TRIC-DT announcements
+- 2 x 15 - 20 minute talks (from different themes)
+- Plenty of room for Q&A and discussions
+
 # Take Part!
 
 ## Next events

--- a/Seminars/README.md
+++ b/Seminars/README.md
@@ -1,5 +1,5 @@
 Welcome to our TRIC-DT Seminar Series!
-**Take part** in this community by attending the [next event](#next-events), [propose or upvoting a new topic](#propose-a-topic) or [sign up to present](#sign-up-as-a-presenter)!
+**Take part** in this community by attending the [next event](#next-events), [propose](#propose-a-topic) or upvoting a new topic or [sign up to present](#sign-up-as-a-presenter)!
 
 # 'Crafting Digital Twins' Seminar Series
 
@@ -7,15 +7,15 @@ The “Crafting Digital Twins: Computational Methods Across Environment, Health 
 
 By uniting researchers to discuss the methodological hurdles in their foundational work, this series will offer immediate value to each team member, enabling you to acquire practical insights applicable to projects at any stage, no matter how “DT-ready”. Beyond the technical learnings, presenting to a broader peer group allows us to see common challenges from fresh perspectives, potentially igniting innovative solutions to our problems.
 
-## Take Part!
+# Take Part!
 
 ## Next events
 We are currently finding dates for first seminars in November & December. If you haven't received an email about this, please email sarana@turing.ac.uk for the doodle link
 
 ## Sign-up as a presenter
-For existing topics, sign up as a presenter by **assigning yourself to an issue** with label /seminar_series and then **commenting with a title** and a few sentences describing your presentations. We will assign a date to each session, once we have researchers from at least two different themes signed up.
+For existing topics, sign up as a presenter by **assigning yourself to an issue** with label `seminar series` and then **commenting with a title** and a few sentences describing your presentations. We will assign a date to each session, once we have researchers from at least two different themes signed up.
 
-We will label issues with 0/idea, 1/assigned, 2/scheduled and 3/completed.
+We will label issues with `0/idea`, `1/assigned`, `2/scheduled` and `3/completed`.
 
 ## Propose a topic
 We’ve opened an issue in this repository for each topic we’re considering. We'd like your input and "votes" on these, and your suggestions for other topics we haven't thought of. We want to invite everyone to collaborate on shaping this seminar series in something that serves the TRIC-DT research community best.

--- a/Seminars/checklist.md
+++ b/Seminars/checklist.md
@@ -1,19 +1,23 @@
 # Checklist for setting up Seminar Series event
 
 
-- [ ] Select [topic from ideas](https://github.com/alan-turing-institute/tric-dt/issues?q=is%3Aopen+is%3Aissue+label%3A%22seminar+series%22+label%3A%220%2F+idea%22) for which min 2 speakers have assigned themselves
-- [ ] Find date that works for speakers
-- [ ] Work out topic details, ask for short abstracts and speaker bios
+- [ ] Select [topic from ideas](https://github.com/alan-turing-institute/tric-dt/issues?q=is%3Aopen+is%3Aissue+label%3A%22seminar+series%22+label%3A%220%2F+idea%22) for which min 2 speakers are assigned or have been suggested, change issue tag to `in planning`.
+- [ ] Find date that works for speakers, assign order and who provides general overview.
+- [ ] Work out topic details, ask for short abstracts, speaker bios and glossary
 - [ ] add to seminar series [next events section in README](https://github.com/alan-turing-institute/tric-dt/tree/seminar_series/Seminars#next-events)
 - [ ] Announce a "save the date" 2 weeks ahead of event on Slack workspace
 - [ ] Create Zoom meeting
-- [ ] Have pre-event meeting with speakers (need this?)
-- [ ] Create Google doc for attendees list (optional to add name, organization, country), collaborative notes,  Q & A, links to speakers' slides or gists for code, resources 
+- [ ] Create HackMD for attendees list (optional to add name, organization, country), collaborative notes,  Q & A, links to speakers' slides or gists for code, resources 
 - [ ] Edit intro slide to show via screenshare at start of call; contains agenda, link to collaborative notes doc 
-- [ ] Run community call 
-  - record call (do we want to record and where do we share videos?)
-- [ ] Extract transcript and share on GitHub repo
+
+- [ ] Run Seminar
+  - Open Zoom call 5 minutes in advance
+  - Announce & Start recording *do we want to record and where do we share videos?*
+  - 5 past, introduce topic, read out any announcements / opportunities, share HackMD with resources & glossary
+  - 10 past, hand over to speaker, monitor chat for questions
+  - 30 minutes before end, open & moderate discussion
+  - 5 minutes before end, announce upcoming event & close
+
+- [ ] Extract transcript / Archive notes and share on GitHub repo
 - [ ] Change tag for event to `3/completed`
-- [ ] Thank the speakers
-- [ ] Record attendance numbers, note any highlights or impact stories, and share with the team
-  - number of attendees, number of countries represented; % of attendees from academia, government, industry, non-profit, other
+- [ ] Record attendance numbers, note any highlights and share with the tric-dt team

--- a/Seminars/checklist.md
+++ b/Seminars/checklist.md
@@ -1,0 +1,19 @@
+# Checklist for setting up Seminar Series event
+
+
+- [ ] Select [topic from ideas](https://github.com/alan-turing-institute/tric-dt/issues?q=is%3Aopen+is%3Aissue+label%3A%22seminar+series%22+label%3A%220%2F+idea%22) for which min 2 speakers have assigned themselves
+- [ ] Find date that works for speakers
+- [ ] Work out topic details, ask for short abstracts and speaker bios
+- [ ] add to seminar series [next events section in README](https://github.com/alan-turing-institute/tric-dt/tree/seminar_series/Seminars#next-events)
+- [ ] Announce a "save the date" 2 weeks ahead of event on Slack workspace
+- [ ] Create Zoom meeting
+- [ ] Have pre-event meeting with speakers (need this?)
+- [ ] Create Google doc for attendees list (optional to add name, organization, country), collaborative notes,  Q & A, links to speakers' slides or gists for code, resources 
+- [ ] Edit intro slide to show via screenshare at start of call; contains agenda, link to collaborative notes doc 
+- [ ] Run community call 
+  - record call (do we want to record and where do we share videos?)
+- [ ] Extract transcript and share on GitHub repo
+- [ ] Change tag for event to `3/completed`
+- [ ] Thank the speakers
+- [ ] Record attendance numbers, note any highlights or impact stories, and share with the team
+  - number of attendees, number of countries represented; % of attendees from academia, government, industry, non-profit, other

--- a/Seminars/checklist.md
+++ b/Seminars/checklist.md
@@ -11,13 +11,15 @@
 - [ ] Edit intro slide to show via screenshare at start of call; contains agenda, link to collaborative notes doc 
 
 - [ ] Run Seminar
+  - *see also Turing Way recommendations for best practices on [chairing remote talks](https://deploy-preview-1567--the-turing-way.netlify.app/collaboration/remote-collab/remote-collab-chairs.html)*
   - Open Zoom call 5 minutes in advance
   - Announce & Start recording *do we want to record and where do we share videos?*
   - 5 past, introduce topic, read out any announcements / opportunities, share HackMD with resources & glossary
   - 10 past, hand over to speaker, monitor chat for questions
-  - 30 minutes before end, open & moderate discussion
+  - 30 minutes before end, open & moderate discussion, for this bit ask people to turn on their cameras if possible.
   - 5 minutes before end, announce upcoming event & close
 
 - [ ] Extract transcript / Archive notes and share on GitHub repo
 - [ ] Change tag for event to `3/completed`
 - [ ] Record attendance numbers, note any highlights and share with the tric-dt team
+


### PR DESCRIPTION
I created a separate folder to collect information around the seminar series. So far it contains a description and instructions for researchers how to participate.

I have also created an issues template that people should use when making suggestions for future topics / events.

The goal is to get everyone involved in creating this seminar collaboratively